### PR TITLE
Handle not found gracefully in read methods of resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Unofficial Terraform Provider for Planetscale :rocket:
 
 - Website: https://planetscale.com
-- Documentation: https://registry.terraform.io/providers/s1ntaxe770r/planetscale/lates
+- Documentation: https://registry.terraform.io/providers/s1ntaxe770r/planetscale/latest
 
 ## Requirements
 

--- a/planetscale/resource_branch.go
+++ b/planetscale/resource_branch.go
@@ -161,6 +161,11 @@ func resourceBranchRead(d *schema.ResourceData, m interface{}) error {
 		Branch:       "",
 	})
 	if err != nil {
+		// Note(turkenh): Handle "Not Found" gracefully
+		if psErr, ok := err.(*ps.Error); ok && psErr.Code == ps.ErrNotFound {
+			d.SetId("")
+			return nil
+		}
 		return errors.New(err.Error())
 	}
 	if err := d.Set("branch", flattenBranch(branchReq)); err != nil {

--- a/planetscale/resource_branch_password.go
+++ b/planetscale/resource_branch_password.go
@@ -180,6 +180,11 @@ func resourceBranchPasswordRead(d *schema.ResourceData, m interface{}) error {
 		PasswordId:   id.(string),
 	})
 	if err != nil {
+		// Note(turkenh): Handle "Not Found" gracefully
+		if psErr, ok := err.(*ps.Error); ok && psErr.Code == ps.ErrNotFound {
+			d.SetId("")
+			return nil
+		}
 		return errors.New(err.Error())
 	}
 


### PR DESCRIPTION
This PR handles "not found" gracefully for the following resources (see #14 for more details):

- planetscale_database
- planetscale_branch
- planetscale_branch_password

Fixes #14